### PR TITLE
The "next" button was screwed up due to incorrect line spacing.

### DIFF
--- a/Part 3/Arrays/Arrays.playground/Pages/Concatenating and Copying.xcplaygroundpage/Contents.swift
+++ b/Part 3/Arrays/Arrays.playground/Pages/Concatenating and Copying.xcplaygroundpage/Contents.swift
@@ -12,4 +12,5 @@ var arrayCopy = array
 
 arrayCopy[2] = "different"
 arrayCopy
-array//: [Next](@next)
+
+//: [Next](@next)


### PR DESCRIPTION
The next button doesn't show in the current version for the Concatenation tab. This fixes that by moving the correct code down a line. 